### PR TITLE
Unified navigation to route and to segment, added `RequestedRoute` property on `Navigator`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="8.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="morelinq" Version="4.3.0" />
+    <PackageVersion Include="morelinq" Version="4.4.0" />
     <PackageVersion Include="NUnit" Version="4.2.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/Ecierge.Uno.Navigation/AttachedProperties/NavigationAttachedProperties.cs
+++ b/Ecierge.Uno.Navigation/AttachedProperties/NavigationAttachedProperties.cs
@@ -60,7 +60,7 @@ public static class Navigation
         var parentSegment = parentNavigationRegion.Segment;
         ImmutableArray<NameSegment> nestedSegments;
         string parentSegmentName;
-        if (parentSegment.Data is DataSegment dataSegment)
+        if (parentSegment.DataSegment is DataSegment dataSegment)
         {
             parentSegmentName = dataSegment.Name;
             nestedSegments = dataSegment.Nested;

--- a/Ecierge.Uno.Navigation/Navigation/NavigationData.cs
+++ b/Ecierge.Uno.Navigation/Navigation/NavigationData.cs
@@ -103,21 +103,25 @@ public class NavigationData : INavigationData
     IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)data).GetEnumerator();
 }
 
-internal static class NavigationDataExtensions
+internal static class RouteExtensions
 {
-    public static void ApplyScopedInstanceServices(this INavigationData navigationData, IServiceProvider serviceProvider)
+    public static void ApplyScopedInstanceServices(this Routing.Route route, IServiceProvider serviceProvider)
     {
+        var navigationData = route.Data;
         var scopedInstanceOptions = serviceProvider.GetService<IOptions<ScopedInstanceRepositoryOptions>>()?.Value;
         if (scopedInstanceOptions is null)
             return;
 
-        var typesToClone = scopedInstanceOptions.TypesToClone;
-        foreach (var value in navigationData.Values)
+        if (navigationData is not null)
         {
-            Type serviceType = value.GetType();
-            if (typesToClone.Contains(serviceType))
+            var typesToClone = scopedInstanceOptions.TypesToClone;
+            foreach (var value in navigationData.Values)
             {
-                serviceProvider.AddScopedInstance(serviceType, value);
+                Type serviceType = value.GetType();
+                if (typesToClone.Contains(serviceType))
+                {
+                    serviceProvider.AddScopedInstance(serviceType, value);
+                }
             }
         }
     }

--- a/Ecierge.Uno.Navigation/Navigation/NavigationRequest.cs
+++ b/Ecierge.Uno.Navigation/Navigation/NavigationRequest.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 namespace Ecierge.Uno.Navigation;
 
 [ImplicitKeys(IsEnabled = false)]
-public abstract partial record NavigationRequest(object Sender, INavigationData? NavigationData)
+public abstract partial record NavigationRequest(object Sender, Routing.Route Route)
 {
     public Guid Id { get; } = Guid.NewGuid();
 
@@ -16,8 +16,8 @@ public abstract partial record NavigationRequest(object Sender, INavigationData?
 public record NameSegmentNavigationRequest(
       object Sender
     , NameSegment Segment
-    , INavigationData? NavigationData = null)
-    : NavigationRequest(Sender, NavigationData)
+    , Routing.Route Route)
+    : NavigationRequest(Sender, Route)
 {
     public override NameSegment NameSegment => Segment;
     public override RouteSegment RouteSegment => Segment;
@@ -29,8 +29,8 @@ public record DataSegmentNavigationRequest(
       object Sender
     , DataSegment Segment
     , object? RouteData
-    , INavigationData? NavigationData = null)
-    : NavigationRequest(Sender, NavigationData)
+    , Routing.Route Route)
+    : NavigationRequest(Sender, Route)
 {
     public override NameSegment NameSegment => Segment.ParentNameSegment;
     public override RouteSegment RouteSegment => Segment;
@@ -48,7 +48,7 @@ public record DialogSegmentNavigationRequest : NavigationRequest
       object sender
     , DialogSegment segment
     , RouteSegment parentSegment
-    , INavigationData? NavigationData = null) : base(sender, NavigationData)
+    , Routing.Route route) : base(sender, route)
     {
         if (parentSegment is DialogSegment)
             throw new ArgumentException("Dialogs must not be nested.", nameof(parentSegment));

--- a/Ecierge.Uno.Navigation/Navigation/NavigationResult.cs
+++ b/Ecierge.Uno.Navigation/Navigation/NavigationResult.cs
@@ -4,6 +4,7 @@ public record struct NavigationResult
 {
     public RouteSegment? SegmentNavigated { get; private set; }
     public object? Result { get; private set; }
+    // The route already corresponds to the current route, no navigation necessary
     public bool IsSkipped { get; private set; }
     public IReadOnlyList<string> Errors { get; private set; }
     public bool Success => SegmentNavigated is not null;

--- a/Ecierge.Uno.Navigation/Navigation/Navigator.cs
+++ b/Ecierge.Uno.Navigation/Navigation/Navigator.cs
@@ -222,7 +222,7 @@ public static class NavigatorExtensions
         // Get the last navigatable segment from which nested segments will be searched within
         RouteSegment? nextSegment = navigator.Region.Segment switch
         {
-            NameSegment nameSegment when nameSegment.Data is DataSegment nestedDataSegment => nestedDataSegment,
+            NameSegment nameSegment when nameSegment.DataSegment is DataSegment nestedDataSegment => nestedDataSegment,
             RouteSegment routeSegment => routeSegment
         };
         foreach (var segmentName in segmentNames)
@@ -248,7 +248,7 @@ public static class NavigatorExtensions
             RouteSegment? nextSegment = segment switch
             {
                 // The next is data
-                NameSegment nameSegment when nameSegment.Data is DataSegment nestedDataSegment => nestedDataSegment,
+                NameSegment nameSegment when nameSegment.DataSegment is DataSegment nestedDataSegment => nestedDataSegment,
                 // The next is dialog
                 RouteSegment routeSegment when segmentName.StartsWith('!') => navigator.FindDialogSegmentToNavigate(segmentName[1..]),
                 // The next is nested
@@ -347,7 +347,7 @@ public static class NavigatorExtensions
     {
         NameSegment segment = navigator.Region.Segment;
         ImmutableArray<NameSegment> nested;
-        if (segment.Data is DataSegment dataSegment)
+        if (segment.DataSegment is DataSegment dataSegment)
             nested = dataSegment.Nested;
         else
             nested = segment.Nested;

--- a/Ecierge.Uno.Navigation/Navigation/Navigator.cs
+++ b/Ecierge.Uno.Navigation/Navigation/Navigator.cs
@@ -283,7 +283,7 @@ public static class NavigatorExtensions
     {
         navigator.RaiseNavigationStarted(() => route);
         // TODO: Ensure that navigation item mapping resolution happens only once
-        route = route with { Data = (navigator.Route.Data ?? NavigationData.Empty).Union(route.Data) };
+        route = route with { Data = (navigator.Parent?.Route.Data ?? NavigationData.Empty).Union(route.Data) };
         NavigationResponse? response = null;
         var currentNavigator = navigator;
         NavigationResult result = default;

--- a/Ecierge.Uno.Navigation/Navigators/BaseNavigators.cs
+++ b/Ecierge.Uno.Navigation/Navigators/BaseNavigators.cs
@@ -33,7 +33,7 @@ public abstract class FactoryNavigator<TTarget> : Navigator<TTarget>
         var view = (FrameworkElement)ServiceProvider.GetRequiredService(viewMap.View);
         if (viewMap.ViewModel is Type viewModelType)
         {
-            var result = Scope.CreateViewModel(request, request.NavigationData);
+            var result = Scope.CreateViewModel(request, request.Route.Data);
             if (result.Success)
             {
                 var viewModel = result.Result;

--- a/Ecierge.Uno.Navigation/Navigators/NavigationViewNavigator.cs
+++ b/Ecierge.Uno.Navigation/Navigators/NavigationViewNavigator.cs
@@ -93,7 +93,7 @@ public class NavigationViewNavigator : SelectorNavigator<NavigationView>
             navigatedName = segmentName;
             navigatedItem = selectedItem;
 
-            var request = new NameSegmentNavigationRequest(s, segment);
+            var request = new NameSegmentNavigationRequest(s, segment, segment.BuildDefaultRoute());
             await NavigateAsync(request);
         };
     }

--- a/Ecierge.Uno.Navigation/Navigators/SelectorBarNavigator.cs
+++ b/Ecierge.Uno.Navigation/Navigators/SelectorBarNavigator.cs
@@ -41,11 +41,11 @@ internal class SelectorBarNavigator : SelectorNavigator<SelectorBar>
             if (isFirstNavigation)
             {
                 isFirstNavigation = false;
-                _ = this.NavigateSegmentAsync(s, segment);
+                _ = this.NavigateLocalSegmentAsync(s, segment);
             }
             else
             {
-                var request = new NameSegmentNavigationRequest(s, segment);
+                var request = new NameSegmentNavigationRequest(s, segment, segment.BuildDefaultRoute());
                 await NavigateAsync(request);
             }
         };

--- a/Ecierge.Uno.Navigation/Routing/Route.cs
+++ b/Ecierge.Uno.Navigation/Routing/Route.cs
@@ -28,7 +28,7 @@ public record DialogSegmentInstance(DialogSegment DialogSegment) : RouteSegmentI
     public override RouteSegment Segment => throw new NotImplementedException("Dialog segments not implemented.");
 }
 
-public record struct Route
+public record Route
 {
     public ImmutableArray<RouteSegmentInstance> Segments { get; init; }
     public INavigationData? Data { get; init; }
@@ -37,6 +37,8 @@ public record struct Route
     public static Route Empty => new Route(ImmutableArray<RouteSegmentInstance>.Empty);
 
     public Route() : this(ImmutableArray<RouteSegmentInstance>.Empty) { }
+
+    public Route(INavigationData? data) : this(ImmutableArray<RouteSegmentInstance>.Empty, data) { }
 
     public Route(ImmutableArray<RouteSegmentInstance> segments, INavigationData? data = null, bool refresh = false)
     {

--- a/Ecierge.Uno.Navigation/Routing/RouteMaps.cs
+++ b/Ecierge.Uno.Navigation/Routing/RouteMaps.cs
@@ -36,22 +36,22 @@ namespace Ecierge.Uno.Navigation
     public record NameSegment : RouteSegment
     {
         public bool IsDefault { get; init; } = false;
-        public bool HasData => Data is not null;
-        public bool HasMandatoryData => Data is not null && Data.IsMandatory;
+        public bool HasData => DataSegment is not null;
+        public bool HasMandatoryData => DataSegment is not null && DataSegment.IsMandatory;
         public ViewMap? ViewMap { get; set; }
-        public DataSegment? Data { get; private init; }
+        public DataSegment? DataSegment { get; private init; }
         public override ImmutableArray<NameSegment> Nested { get; protected init; } = ImmutableArray<NameSegment>.Empty;
-        public override ImmutableArray<NameSegment> NestedAfterData => Data is not null ? Data.Nested : Nested;
+        public override ImmutableArray<NameSegment> NestedAfterData => DataSegment is not null ? DataSegment.Nested : Nested;
 
-        public NameSegment(string name, ViewMap? view, DataSegment data) : base(name)
+        public NameSegment(string name, ViewMap? view, DataSegment dataSegment) : base(name)
         {
             ViewMap = view;
-            data = data ?? throw new ArgumentNullException(nameof(data));
+            dataSegment = dataSegment ?? throw new ArgumentNullException(nameof(dataSegment));
             IsDefault = false;
-            if (data is not null)
+            if (dataSegment is not null)
             {
-                Data = data;
-                data.ParentSegment = this;
+                DataSegment = dataSegment;
+                dataSegment.ParentSegment = this;
             }
         }
 
@@ -76,20 +76,22 @@ namespace Ecierge.Uno.Navigation
                 }
             };
             INavigationData navigationData = (data as INavigationData)!;
-            if (Data is not null)
+            if (DataSegment is not null)
             {
-                if (data is null && Data.IsMandatory)
+                if (data is null && DataSegment.IsMandatory)
                     throw new ArgumentNullException(nameof(data), "Data is mandatory.");
                 if (navigationData is not null)
                 {
-                    list.Add(new DataSegmentInstance(Data, null, navigationData[Data.Name]));
+                    // TODO: Do something with primitive value that is null now
+                    list.Add(new DataSegmentInstance(DataSegment, null, navigationData[DataSegment.Name]));
                 }
                 else
                 {
-                    navigationData = NavigationData.Empty.Add(Data.Name, data!);
-                    list.Add(new DataSegmentInstance(Data, null, data));
+                    navigationData = NavigationData.Empty.Add(DataSegment.Name, data!);
+                    // TODO: Do something with primitive value that is null now
+                    list.Add(new DataSegmentInstance(DataSegment, null, data));
                 }
-                AddDefaultSegments(Data);
+                AddDefaultSegments(DataSegment);
             }
             else
             {
@@ -169,7 +171,7 @@ namespace Ecierge.Uno.Navigation.Helpers
             var viewMap = a.ViewMap ?? b.ViewMap;
             if (a.HasData)
             {
-                var dataSegment = Merge(a.Data!, b.Data!);
+                var dataSegment = Merge(a.DataSegment!, b.DataSegment!);
                 return new NameSegment(a.Name, viewMap!, dataSegment);
             }
             else


### PR DESCRIPTION
Previously navigation to route and to segment worked differently.

Navigation to route:
1. Raise started event
2. Navigate all segments
3. Raise end event

Navigation to segment:
Like above but for the current segment and for all default segments inside

Now they work the same way.
Also now `Navigator` has `RequestedRoute` to be able to get the currently requested route from it and down below the current navigators hierarchy

Also, fixed the bug with navigation data messed up on `NavigateRouteAsync`